### PR TITLE
close the file write stream using try-with-resources

### DIFF
--- a/src/main/java/com/udacity/webcrawler/json/CrawlResultWriter.java
+++ b/src/main/java/com/udacity/webcrawler/json/CrawlResultWriter.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 
 /**
@@ -34,8 +35,9 @@ public final class CrawlResultWriter {
     // This is here to get rid of the unused variable warning.
     Objects.requireNonNull(path);
     // TODO: Fill in this method.
-    Writer writer = Files.newBufferedWriter(path);
-    write(writer);
+    try (Writer writer = Files.newBufferedWriter(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+      write(writer);
+    }
   }
 
   /**

--- a/src/main/java/com/udacity/webcrawler/main/WebCrawlerMain.java
+++ b/src/main/java/com/udacity/webcrawler/main/WebCrawlerMain.java
@@ -42,9 +42,10 @@ public final class WebCrawlerMain {
       Path outputPath = Path.of(config.getResultPath());
       resultWriter.write(outputPath);
     } else {
-      Writer writer = new BufferedWriter(new OutputStreamWriter(System.out));
-      resultWriter.write(writer);
-      writer.flush();
+      try(Writer writer = new BufferedWriter(new OutputStreamWriter(System.out))) {
+        resultWriter.write(writer);
+        writer.flush();
+      }
     }
 
     // TODO: Write the profile data to a text file (or System.out if the file name is empty)
@@ -52,9 +53,10 @@ public final class WebCrawlerMain {
       Path outputPath = Path.of(config.getProfileOutputPath());
       profiler.writeData(outputPath);
     } else {
-      Writer writer = new BufferedWriter(new OutputStreamWriter(System.out));
-      profiler.writeData(writer);
-      writer.flush();
+      try(Writer writer = new BufferedWriter(new OutputStreamWriter(System.out))) {
+        profiler.writeData(writer);
+        writer.flush();
+      }
     }
   }
 


### PR DESCRIPTION
## Addressing File Writer Stream Not Closing

This request ensures that a `try-with-resources` is used on the `CrawlResultWriter#write` and `WebCrawlerMain`. It also uses the `StandardOpenOption.CREATE` method to open files to aid the creation of files if they do no exist on the `CrawlResultWriter#write` method.

<img width="1177" alt="Screenshot 2023-05-05 at 3 21 11 PM" src="https://user-images.githubusercontent.com/40724004/236553374-89e9abe1-a1f8-44dd-8ed8-c11a2a15d759.png">
