### PR TITLE
Remove `try-with-resources` from Main

### DIFF
--- a/src/main/config/sample_config.json
+++ b/src/main/config/sample_config.json
@@ -6,5 +6,5 @@
   "maxDepth": 20,
   "timeoutSeconds": 5,
   "popularWordCount": 5,
-  "profileOutputPath": ""
+  "profileOutputPath": "profileData.txt"
 }

--- a/src/main/java/com/udacity/webcrawler/json/CrawlerConfiguration.java
+++ b/src/main/java/com/udacity/webcrawler/json/CrawlerConfiguration.java
@@ -169,7 +169,7 @@ public final class CrawlerConfiguration {
    *
    * <p>See {@link com.udacity.webcrawler.json.CrawlResult}.
    */
-  public String   getResultPath() {
+  public String getResultPath() {
     return resultPath;
   }
 

--- a/src/main/java/com/udacity/webcrawler/main/WebCrawlerMain.java
+++ b/src/main/java/com/udacity/webcrawler/main/WebCrawlerMain.java
@@ -42,10 +42,9 @@ public final class WebCrawlerMain {
       Path outputPath = Path.of(config.getResultPath());
       resultWriter.write(outputPath);
     } else {
-      try(Writer writer = new BufferedWriter(new OutputStreamWriter(System.out))) {
+      Writer writer = new BufferedWriter(new OutputStreamWriter(System.out));
         resultWriter.write(writer);
         writer.flush();
-      }
     }
 
     // TODO: Write the profile data to a text file (or System.out if the file name is empty)


### PR DESCRIPTION
This repo removes some white spaces, adds the output path back and mainly removes the `try-with-resources` from the Main method in charge of writing into console if the path is missing. The catch was closing the file causing a bug that would not allow the stats to print. Stats print again by removing the `try-with-resource`.