### PR TITLE
Ensure Atomicity and Prevent Race Condition on CustomCrawlTask#Compute

### DIFF
--- a/src/main/java/com/udacity/webcrawler/ParallelWebCrawler.java
+++ b/src/main/java/com/udacity/webcrawler/ParallelWebCrawler.java
@@ -108,13 +108,8 @@ final class ParallelWebCrawler implements WebCrawler {
       }
       PageParser.Result result = parserFactory.get(url).parse();
 
-      for (Map.Entry<String, Integer> e : result.getWordCounts().entrySet()) {
-        if (counts.containsKey(e.getKey())) {
-          counts.put(e.getKey(), e.getValue() + counts.get(e.getKey()));
-        } else {
-          counts.put(e.getKey(), e.getValue());
-        }
-      }
+      result.getWordCounts().forEach((key, value) ->
+              counts.merge(key, value, Integer::sum));
 
       List<CustomCrawlTask> customCrawlTask = result.getLinks().stream()
               .map(link -> new CustomCrawlTask(maxDepth - 1, deadline, link, counts, visitedUrls))


### PR DESCRIPTION
This request refactors the code to use a `forEach` loop that uses the `merge` method to ensure atomicity. This will prevent race conditions. 

All tests pass.

<img width="911" alt="image" src="https://user-images.githubusercontent.com/40724004/236638537-1d117221-7136-4f6a-81bd-4cc00c6e0c78.png">
