### PR TITLE
ProfilingMethodInterceptor checks for Object Equality

### DIFF
--- a/src/main/java/com/udacity/webcrawler/profiler/ProfilingMethodInterceptor.java
+++ b/src/main/java/com/udacity/webcrawler/profiler/ProfilingMethodInterceptor.java
@@ -48,7 +48,7 @@ final class ProfilingMethodInterceptor implements InvocationHandler {
         throw ex;
       }
     } finally {
-      if (isProfiled) {
+      if (isProfiled || method.getDeclaringClass().equals(Object.class)) {
         Duration duration = Duration.between(start, clock.instant());
         state.record(delegate.getClass(), method, duration);
       }


### PR DESCRIPTION
As part of the requirements the `ProfilingMethodInterceptor` now checks for object equality.

All checks pass.

<img width="580" alt="image" src="https://user-images.githubusercontent.com/40724004/236710241-17dab062-5d1a-429b-8116-c853108d9038.png">
